### PR TITLE
Fix GHSA-4wrc-f8pq-fpqp - org.springframework:spring-web

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <ns0:dependency>
             <ns0:groupId>org.springframework</ns0:groupId>
             <ns0:artifactId>spring-web</ns0:artifactId>
-            <ns0:version>5.3.38</ns0:version>
+            <ns0:version>6.0.0</ns0:version>
         </ns0:dependency>
 
         


### PR DESCRIPTION
**Issue:** Pivotal Spring Framework contains unsafe Java deserialization methods

**Impact:** This could affect your application if improperly handled.

**Fix:** Consider upgrading <b>org.springframework:spring-web</b> to the latest version.